### PR TITLE
Update author format so multiple author update is not breaking.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-    "extends": "airbnb"
+    "extends": "airbnb",
+    "parser": "babel-eslint",
 };

--- a/src/pages/screens/BibliographyScreen.jsx
+++ b/src/pages/screens/BibliographyScreen.jsx
@@ -35,11 +35,17 @@ class BibliographyPage extends Component {
           metadata = await this.metascraper({ html, url });
         }
         let dateString = metadata.date;
-        if(dateString) dateString = new Date(dateString);
+        if (dateString) dateString = new Date(dateString);
+
+        const authors = [];
+        if (metadata.author) {
+          authors.push(metadata.author);
+        }
+
         const citation = {
           url: metadata.url || null,
           article: metadata.title || null,
-          author: metadata.author || null,
+          authors,
           website: metadata.publisher || null,
           publisher: null,
           datePublished: dateString || null,

--- a/src/pages/screens/CitationScreen.jsx
+++ b/src/pages/screens/CitationScreen.jsx
@@ -32,7 +32,7 @@ class Citation extends Component {
       <CitationView
         website={citation.citation.website}
         article={citation.citation.article}
-        author={citation.citation.author}
+        authors={citation.citation.authors}
         publisher={citation.citation.publisher}
         datePublished={citation.citation.datePublished}
         dateRetrieved={citation.citation.dateRetrieved}

--- a/src/pages/views/CitationView.jsx
+++ b/src/pages/views/CitationView.jsx
@@ -13,7 +13,7 @@ export default class CitationView extends PureComponent {
     const {
       website,
       article,
-      author,
+      authors,
       publisher,
       datePublished,
       dateRetrieved,
@@ -61,7 +61,7 @@ export default class CitationView extends PureComponent {
             fieldName="Author"
             inputType="text"
             name="author"
-            value={author}
+            value={authors[0]}
             onChange={(field, value) => updateAuthor(value)}
           />
           <FormField

--- a/src/services/Converter.js
+++ b/src/services/Converter.js
@@ -5,7 +5,7 @@ const monthName = ['January', 'February', 'March', 'April', 'May', 'June',
 
 function replaceAngleBrackets(data) {
   const newData = {};
-  newData.author = data.author ? data.author.replace(/</g, '&lt;') : undefined;
+  newData.authors = data.authors.map(author => author.replace(/</g, '&lt;'));
   newData.date = data.datePublished || undefined;
   newData.publisher = data.publisher ? data.publisher.replace(/</g, '&lt;') : undefined;
   newData.website = data.website ? data.website.replace(/</g, '&lt;') : undefined;
@@ -18,8 +18,9 @@ function replaceAngleBrackets(data) {
 export function toAPA(data) {
   let citation = '';
   const {
-    author, date, publisher, title, dateAccessed, url
+    authors, date, publisher, title, dateAccessed, url
   } = replaceAngleBrackets(data);
+  const author = authors[0];
 
   if (author) {
     const nameArr = author.split(' ');
@@ -60,8 +61,9 @@ export function toAPA(data) {
 export function toMLA(data) {
   let citation = '';
   const {
-    author, date, publisher, website, title, url
+    authors, date, publisher, website, title, url
   } = replaceAngleBrackets(data);
+  const author = authors[0];
 
   if (author) {
     const nameArr = author.split(' ');
@@ -120,8 +122,9 @@ http://www.bibme.org/citation-guide/chicago/website/
 export function toChicago(data) {
   let citation = '';
   const {
-    author, date, publisher, website, title, dateAccessed, url
+    authors, date, publisher, website, title, dateAccessed, url
   } = replaceAngleBrackets(data);
+  const author = authors[0];
 
   if (author) {
     const nameArr = author.split(' ');
@@ -185,8 +188,9 @@ https://www.mendeley.com/guides/harvard-citation-guide
 export function toHarvard(data) {
   let citation = '';
   const {
-    author, date, website, title, dateAccessed, url
+    authors, date, website, title, dateAccessed, url
   } = replaceAngleBrackets(data);
+  const author = authors[0];
 
   if (author) {
     const nameArr = author.split(' ');

--- a/src/stores/BibliographyStore.js
+++ b/src/stores/BibliographyStore.js
@@ -6,7 +6,7 @@ import {
 
 const Citation = types.model({
   article: types.maybeNull(types.string),
-  author: types.maybeNull(types.string),
+  authors: types.optional(types.array(types.string), []),
   publisher: types.maybeNull(types.string),
   website: types.maybeNull(types.string),
   datePublished: types.maybeNull(types.Date),

--- a/src/stores/CitationStore.js
+++ b/src/stores/CitationStore.js
@@ -7,7 +7,7 @@ import {
 const CitationStoreModel = types
   .model('Citation', {
     article: types.maybeNull(types.string),
-    author: types.maybeNull(types.string),
+    authors: types.optional(types.array(types.string), []),
     website: types.maybeNull(types.string),
     publisher: types.maybeNull(types.string),
     datePublished: types.maybeNull(types.Date),
@@ -21,7 +21,7 @@ const CitationStoreModel = types
     saveCitation() {
       localStorage.setItem('CurrentCitation', JSON.stringify({
         article: self.article,
-        author: self.author,
+        authors: self.authors,
         website: self.website,
         publisher: self.publisher,
         datePublished: self.datePublished,
@@ -32,7 +32,7 @@ const CitationStoreModel = types
     },
     setCitation(citation) {
       self.article = citation.article;
-      self.author = citation.author;
+      self.authors = citation.authors.slice(); // copy by value, not reference, for display in CitationView
       self.website = citation.website;
       self.publisher = citation.publisher;
       self.datePublished = citation.datePublished ? new Date(citation.datePublished) : null;
@@ -46,7 +46,7 @@ const CitationStoreModel = types
       this.saveCitation();
     },
     updateAuthor(name) {
-      self.author = name;
+      self.authors[0] = name;
       this.saveCitation();
     },
     updateWebsite(site) {
@@ -71,7 +71,7 @@ const CitationStoreModel = types
     },
     clearCitation() {
       self.article = emptyCitation.article;
-      self.author = emptyCitation.author;
+      self.authors = emptyCitation.authors;
       self.website = emptyCitation.website;
       self.publisher = emptyCitation.publisher;
       self.datePublished = emptyCitation.datePublished;
@@ -85,7 +85,7 @@ const CitationStoreModel = types
     get citation() {
       const citation = {
         article: self.article,
-        author: self.author,
+        authors: self.authors.slice(), // copy by value, not reference, for mobx
         website: self.website,
         publisher: self.publisher,
         datePublished: self.datePublished,
@@ -103,7 +103,7 @@ const CitationStoreModel = types
 
 export const emptyCitation = {
   article: null,
-  author: null,
+  authors: [],
   website: null,
   publisher: null,
   datePublished: null,


### PR DESCRIPTION
The multiple author change is relatively big and looks like it won't be ready for the beta release. This PR changes the author string in the store to be an array of authors. The current functionality is unchanged, but when the multiple author update is made, it won't break the store.